### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/wwbgo/eef47fd3-4191-4f9a-950e-a14e2592e724/d27b0be5-96a9-4a94-b4ad-aed2e24ddd4f/_apis/work/boardbadge/4d754323-b73a-4de1-8322-7b8c68520c81)](https://dev.azure.com/wwbgo/eef47fd3-4191-4f9a-950e-a14e2592e724/_boards/board/t/d27b0be5-96a9-4a94-b4ad-aed2e24ddd4f/Microsoft.RequirementCategory)
 ## Welcome to GitHub Pages
 
 You can use the [editor on GitHub](https://github.com/wwbgo/home/edit/master/README.md) to maintain and preview the content for your website in Markdown files.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/wwbgo/eef47fd3-4191-4f9a-950e-a14e2592e724/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.